### PR TITLE
docs: improve README for cuda 11.x usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ pip install cupy-cuda12x  # use cupy-cuda11x for CUDA 11.x
 pip install git+https://github.com/rusty1s/pytorch_scatter.git
 pip install flash-attn --no-build-isolation
 
+# For CUDA 11.x
+# export CC=/usr/bin/gcc-9
+# export CXX=/usr/bin/g++-9
+
 # Install warpconvnet from source
 git clone https://github.com/NVlabs/WarpConvNet.git
 cd WarpConvNet
 git submodule update --init 3rdparty/cutlass
-pip install .
+pip install .  # For CUDA 11.x: pip install . --no-build-isolation
 ```
 
 Available optional dependency groups:


### PR DESCRIPTION
This PR is making it easier to install the repo using CUDA 11.x.
If you try to follow the installation instructions of the current README, there will be a version mismatch between the installed torch of the environment and the torch used in the isolated build environment. Also, gcc >9 is incompatible with CUDA 11.x