### PR TITLE
Fix type mismatch when non-default float types are used in sparse_reduce

### DIFF
--- a/warpconvnet/nn/functional/sparse_pool.py
+++ b/warpconvnet/nn/functional/sparse_pool.py
@@ -99,6 +99,7 @@ def sparse_reduce(
             batch_indexed_out_coords.shape[0],
             in_features.shape[1],
             device=voxels.device,
+            dtype=voxels.dtype,
         )
         new_out_features[unique_out_maps] = out_features
         out_features = new_out_features


### PR DESCRIPTION
Currently, `sparse_reduce` does not specify dtype when initializing `new_out_features` with zeros:

https://github.com/NVlabs/WarpConvNet/blob/d9082e8651ef77c59099b185597e75d09b0de0c2/warpconvnet/nn/functional/sparse_pool.py#L98-L102

This leads to an error when using any type other than `torch.float32`:

```
File "/opt/conda/lib/python3.11/site-packages/warpconvnet/nn/functional/sparse_pool.py", line 103, in sparse_reduce
    new_out_features[unique_out_maps] = out_features
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and Double for the source.
```

This commit fixes the issue. I have also looked through all other uses of `torch.zeros` in the code. I did not find any other parts that do not specify a data type save for one line:

https://github.com/NVlabs/WarpConvNet/blob/d9082e8651ef77c59099b185597e75d09b0de0c2/warpconvnet/nn/modules/mlp.py#L92

But since it's part of initializing a module, it should probably be fine, as the types of module weights are usualy cast all at once once the model was fully instantiated.