### PR TITLE
Fix non-tuple return in wmma backward benchmark

### DIFF
--- a/warpconvnet/nn/functional/sparse_conv/detail/implicit_wmma.py
+++ b/warpconvnet/nn/functional/sparse_conv/detail/implicit_wmma.py
@@ -89,7 +89,7 @@ def _wmma_implicit_gemm_backward_logic(
     min_dtype = _min_dtype(in_features.dtype, weight.dtype, grad_output.dtype)
     if min_dtype not in [torch.float16, torch.bfloat16]:
         # wmma not supported for data types other than float16 and bfloat16
-        return int(_C.gemm.GemmStatus.kErrorInvalidParameters)
+        return int(_C.gemm.GemmStatus.kErrorInvalidParameters), -1
     _grad_output_detached = grad_output.contiguous().detach().to(dtype=min_dtype)
     _in_features_detached = in_features.contiguous().detach().to(dtype=min_dtype)
     _weight_detached = weight.contiguous().detach().to(dtype=min_dtype)


### PR DESCRIPTION
The recent change d9082e8651ef77c59099b185597e75d09b0de0c2 breaks backward pass benchmark, due to all calls of `_wmma_implicit_gemm_backward_logic` doing tuple unpacking expecting two elements.

Since other non-tensor returns give the index `i` as the second element, I set the return index to -1, as the return happens before any iterations. If there is a better integer value to return, we can change it.