### PR TITLE
fix parse arch-specific suffixes in TORCH_CUDA_ARCH_LIST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,11 @@ if _HAS_TORCH:
     if cuda_arch_list:
         for arch in cuda_arch_list.replace(",", " ").replace(";", " ").split():
             arch = arch.strip().rstrip("+")
+            # Strip PyTorch-style suffixes (e.g. "9.0a" arch-specific, "8.0+PTX")
+            # before parsing as a float.
+            if arch.upper().endswith("PTX"):
+                arch = arch[: -len("PTX")].rstrip("+")
+            arch = arch.rstrip("aA")
             try:
                 _arch_values.append(float(arch))
             except ValueError:


### PR DESCRIPTION
## Summary
- `TORCH_CUDA_ARCH_LIST` entries like `9.0a` (arch-specific, used for Hopper WGMMA) or `8.0+PTX` failed `float()` parsing in `setup.py` and were silently dropped via a bare `except ValueError: pass`.
- As a result, `_has_sm90_target` was never set even though `9.0a` was requested (e.g. in `.github/workflows/build_wheels.yml`), so no `sm_90a` gencode flag was emitted — and because other explicit `-gencode` flags were already present, PyTorch's own arch-flag auto-injection was also suppressed. Wheels ended up built with **no Hopper (H100/sm_90a) support** despite `9.0a` being in the arch list.
- Fix: strip the trailing `a`/`A` suffix (and `+PTX`) before parsing the arch value as a float, so `9.0a` correctly resolves to `9.0` and the existing sm_90a handling further down kicks in.

## Test plan
- [x] Verified the parsing logic in isolation: `TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0a"` now yields `_arch_values = [8.0, 8.6, 8.9, 9.0]`.
- [x] CI: confirm `build_wheels.yml` wheels now include `sm_90a` code (e.g. via `cuobjdump --list-elf` on the built extension).